### PR TITLE
Fixing CLS

### DIFF
--- a/components/member-profile/member-profile.module.scss
+++ b/components/member-profile/member-profile.module.scss
@@ -1,5 +1,6 @@
 .profilePic {
   width: 180px;
+  height: 180px;
   border-radius: 50%;
 }
 

--- a/components/pages/index/home-page.module.scss
+++ b/components/pages/index/home-page.module.scss
@@ -4,7 +4,8 @@
 
 .img {
   display: inline-block;
-  max-width: 300px;
+  width: 300px;
+  height: 300px;
   margin: 0 auto;
   border-radius: 50%;
   margin-bottom: 30px;


### PR DESCRIPTION
Fixes #54  
From what I could understand, I had to specify the dimensions of the image so that space can be allocated in the DOM before it loads and doesn't cause the layout to shift suddenly.

Here is a frame from Lighthouse:
![image](https://user-images.githubusercontent.com/56217868/90050794-56866280-dcf4-11ea-850e-311b49efd76e.png)

Before: 
![image](https://user-images.githubusercontent.com/56217868/90052259-86cf0080-dcf6-11ea-8b4e-148c593cdeca.png)

After:
![image](https://user-images.githubusercontent.com/56217868/90051958-20e27900-dcf6-11ea-93be-ad68005e7bc7.png)

Looks good to me, but the CLS score is around 0.249 (was around 0.374 before) which means there is scope for improvement.
Please provide your reviews so I can understand more about fixing CLS and eventually help RDS :)

Thank you!