### PR TITLE
Changed API endpoint for fetching pull requests

### DIFF
--- a/helper-functions/getPRs.js
+++ b/helper-functions/getPRs.js
@@ -1,6 +1,6 @@
 import { fetch } from './fetch';
 
-const PRbaseURL = 'https://staging-api.realdevsquad.com/pullrequests';
+const PRbaseURL = 'https://staging-api.realdevsquad.com/pullrequests/user';
 
 const getPRsbyUser = async (rdsId) => {
   const res = await fetch(`${PRbaseURL}/${rdsId}`);


### PR DESCRIPTION
Since the API endpoint for fetching PRs has changed from `pullrequests/:username` to `pullrequests/user/:username`, it had to be reflected on the frontend as well.
