### PR TITLE
Fix harcoded image name

### DIFF
--- a/helper-functions/urls.js
+++ b/helper-functions/urls.js
@@ -5,7 +5,7 @@ const PRbaseURL = 'https://staging-api.realdevsquad.com/pullrequests/user';
  *
  * @param {string} rdsId
  */
-const getImgURL = (rdsId) => `${baseURL}/members/${rdsId}/img.png`;
+const getImgURL = (rdsId, img) => `${baseURL}/members/${rdsId}/${img}`;
 
 /**
  *

--- a/pages/[id]/index.js
+++ b/pages/[id]/index.js
@@ -26,7 +26,6 @@ export async function getServerSideProps(context) {
   const {
     params: { id }
   } = context;
-  const imageLink = getImgURL(id);
   const jsonUrl = getDataURL(id);
   const userPRUrl = getPRsUrl(id);
 
@@ -41,6 +40,7 @@ export async function getServerSideProps(context) {
 
     const getPRsbyUser = await fetch(userPRUrl);
     const { pullRequests } = getPRsbyUser.data;
+    const imageLink = getImgURL(id, data.img);
 
     return { props: { imageLink, data, pullRequests } };
   } catch (e) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -43,7 +43,7 @@ export async function getServerSideProps(context) {
         jsonObj = await resp1.json();
         membersArr.push({
           ...jsonObj,
-          img_url: getImgURL(rdsid)
+          img_url: getImgURL(rdsid, jsonObj.img)
         });
       }
     }


### PR DESCRIPTION
Closes: #104 

Use the image name returned in the member's data response to fetch the image.

Earlier the image name was hardcoded to `img.png`, so members had to add an image compulsorily named `img.png`.

Now, they just need to ensure that the image they add is correctly described in the `img` key in the member's `data.json`.

For example:

A new member adds their information in the `website-static` project as follows -- 

```
.
├── members
│   ├── anon
│   │   ├── data.json
│   │   └── profile.jpg
```

Then they would need to add it as following in `data.json` -- 

```
{
  "id": "anon"
  "img": "./profile.jpg",
}
```