### PR TITLE
Ensuring proper maximum height for badge icons

### DIFF
--- a/components/member-profile/member-profile.module.scss
+++ b/components/member-profile/member-profile.module.scss
@@ -65,6 +65,7 @@
 
 .badge {
   max-width: 64px;
+  max-height: 64px;
   margin-right: 25px;
 }
 


### PR DESCRIPTION
Solves bug #130

Adding max-height to avoid stretching of badge icons

![Screenshot from 2021-02-23 18-51-14](https://user-images.githubusercontent.com/12375430/108849501-353df180-7608-11eb-9071-d2179951e18b.png)
