### PR TITLE
Add wallet details in member profile

### DIFF
--- a/components/member-card/card.module.scss
+++ b/components/member-card/card.module.scss
@@ -79,6 +79,65 @@
   font-size: 0.88rem;
 }
 
+.showWallet, .showMemberWallet{
+  display: flex;
+  flex-wrap: wrap;
+  margin: 10px 0;
+  justify-content: center;
+}
+
+.walletContainer {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  align-items: center;
+  border-radius: 2px;
+  width: 150px;
+  height: 70px;
+  padding: 10px 5px 2px;
+  margin-bottom: 8px;
+  margin-left: 6px;
+  background-color: #EEEEEE;
+
+  .coinData {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .coinData>p {
+    height: 2px;
+  }
+
+  .coinData>p:first-child {
+    font-size: 12px;
+    font-weight: 500;
+    transform: translateY(-25px);
+    margin-right: 8px;
+  }
+
+  .coinData>p:last-child {
+    font-size: 20px;
+    font-weight: 700;
+  }
+
+  .coinDinero{
+    background-color: green;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    box-shadow: rgb(0, 0, 0) 3px 3px 3px;
+    border: 1px solid green;
+  }
+  .coinNeelam{
+    background-color: blue;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    box-shadow: rgb(0, 0, 0) 3px 3px 3px;
+    border: 1px solid blue;
+  }
+}
+
 @media only screen and (min-width: 1024px) {
   .showMemberSkills{
     justify-content: flex-start;

--- a/components/member-card/show-wallet.js
+++ b/components/member-card/show-wallet.js
@@ -1,0 +1,76 @@
+import classNames from 'components/member-card/card.module.scss';
+import { CURRENCIES, walletURL } from 'helper-functions/urls';
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+
+const Coins = (props) => {
+  const { coin, balance } = props;
+  return (
+    <div className={classNames.walletContainer}>
+      <div className={classNames.coinData}>
+        <p>{coin}</p>
+        <p>{balance}</p>
+      </div>
+      <div
+        className={
+          coin === CURRENCIES.NEELAM ? classNames.coinNeelam : classNames.coinDinero
+        }></div>
+    </div>
+  );
+};
+
+const ShowWallet = ({ show }) => {
+  const [currencies, setCurrencies] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+  const coins = [];
+  useEffect(() => {
+    const fetchData = async () => {
+      await fetch(walletURL, { credentials: 'include' })
+        .then((res) => {
+          if (res.status >= 400 && res.status < 600) {
+            throw new Error('Bad response from server');
+          }
+          return res.json();
+        })
+        .then((resJson) => {
+          const currencyBalance = resJson.wallet.currencies;
+          for (const name in currencyBalance) {
+            coins.push({
+              name,
+              balance: currencyBalance[name]
+            });
+          }
+          setCurrencies(coins);
+          setIsLoading(false);
+        })
+        .catch((err) => {
+          setIsError(true);
+          console.log(err);
+        });
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <div className={show ? classNames.showMemberSkills : classNames.showSkills}>
+      {!isError && isLoading ? (
+        <p>Loading...</p>
+      ) : (
+        currencies.map((coin) => <Coins coin={coin.name} balance={coin.balance} key={coin.name} />)
+      )}
+    </div>
+  );
+};
+
+ShowWallet.propTypes = {
+  show: PropTypes.bool.isRequired
+};
+
+Coins.propTypes = {
+  coin: PropTypes.string.isRequired,
+  balance: PropTypes.number.isRequired
+};
+
+export default ShowWallet;

--- a/components/member-profile/index.js
+++ b/components/member-profile/index.js
@@ -7,6 +7,7 @@ import ContributionType from 'components/member-profile/contribution-type/';
 import { motion } from 'framer-motion';
 import Modal from 'components/modal';
 import ShowSkills from 'components/member-card/show-skills';
+import ShowWallet from 'components/member-card/show-wallet';
 
 const renderBadgeImages = (badges) =>
   badges.map((badge) => (
@@ -79,6 +80,7 @@ const Profile = (props) => {
               </div>
             )}
             {devUser && <ShowSkills show={true} />}
+            {devUser && <ShowWallet show={true} />}
             <div>
               <button
                 type="button"

--- a/components/member-profile/member-profile.module.scss
+++ b/components/member-profile/member-profile.module.scss
@@ -61,6 +61,12 @@
   flex-wrap: wrap;
 }
 
+.walletContainer {
+  margin-top: 20px;
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .badge {
   max-width: 64px;
   max-height: 64px;

--- a/helper-functions/urls.js
+++ b/helper-functions/urls.js
@@ -1,6 +1,11 @@
 const baseURL = `https://api.realdevsquad.com`;
 const imgBaseURL = `https://raw.githubusercontent.com/Real-Dev-Squad/website-static/main`;
 const getMembersURL = `${baseURL}/members`;
+const walletURL = `${baseURL}/wallet`;
+const CURRENCIES = {
+  NEELAM: 'neelam',
+  DINERO: 'dinero'
+};
 
 /**
  *
@@ -26,4 +31,12 @@ const getContributionsURL = (rdsId) => `${baseURL}/contributions/${rdsId}`;
  */
 const getActiveTasksURL = (rdsId) => `${baseURL}/tasks/${rdsId}?status=active`;
 
-export { getImgURL, getMembersDataURL, getContributionsURL, getMembersURL, getActiveTasksURL };
+export {
+  getImgURL,
+  getMembersDataURL,
+  getContributionsURL,
+  getMembersURL,
+  getActiveTasksURL,
+  walletURL,
+  CURRENCIES
+};


### PR DESCRIPTION
The wallet details of the user are now visible on the member profile page, screenshots attached. 

![Capture](https://user-images.githubusercontent.com/61474917/128772432-280a9483-6a5b-430b-9c2b-06e2e29f00b7.PNG)

![Capturemob](https://user-images.githubusercontent.com/61474917/128772746-1b09d1b8-9821-4782-a4a7-0670460e3c8b.PNG)


Currently the wallet details are only visible when `dev=true` as per the requirements.
