### PR TITLE
fix profile picture

### DIFF
--- a/src/components/member-profile/index.js
+++ b/src/components/member-profile/index.js
@@ -358,9 +358,9 @@ const Profile = (props) => {
           <div className={classNames.memberDetails}>
             <motion.img
               layoutId={username}
-              src={imageLink}
+              src={imageLink.w_200}
               className={classNames.profilePic}
-              alt="ProfilePicture"
+              alt={fullName}
             />
             <div className={classNames.personalInfo}>
               <h1 className={classNames.profileName}>{memberName}</h1>


### PR DESCRIPTION
### What is the change?

FIxed user profile picture display in the profile page, previously it was not showing up

### Is it bug?

- Steps to repro
- Expected
- Actual

### \*Dev Tested?

- [x] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [x] Web

#### Browsers

- [x] Chrome
- [ ] Safari
- [x] Firefox

### Before / After Change Screenshots

![Screenshot from 2021-11-26 12-33-42](https://user-images.githubusercontent.com/34452139/143540531-2ba606e4-add6-41ba-b130-e0173660f8fa.png)

> For visual or interaction changes. Can be video / screenshot.
![Screenshot from 2021-11-26 12-33-50](https://user-images.githubusercontent.com/34452139/143540526-b0a6c707-3c92-4d86-bab0-a4c7fa697828.png)