### PR TITLE
Fetch members images from cloudinary

### DIFF
--- a/src/components/member-card/index.js
+++ b/src/components/member-card/index.js
@@ -19,10 +19,6 @@ const Card = ({ developerInfo }) => {
   ];
   const fullName = `${`${first_name} ${last_name}`}`;
 
-  const brokenImageHandler = (e) => {
-    e.target.src = '/images/Avatar.png';
-  };
-
   const renderName = (userFullName, userName) =>
     userFullName.length > 20 ? userName : userFullName;
 
@@ -31,8 +27,7 @@ const Card = ({ developerInfo }) => {
       {!isMember && dev && <SuperUserOptions username={username} />}
       <motion.img
         layoutId={username}
-        src={`${img_url}?${Math.random() * 100}`}
-        onError={brokenImageHandler}
+        src={img_url}
         className={
           isMember ? classNames.imgContainer : classNames.imgContainerNewMember
         }

--- a/src/helper-functions/urls.js
+++ b/src/helper-functions/urls.js
@@ -1,14 +1,7 @@
 const baseURL = `https://api.realdevsquad.com`;
-const imgBaseURL = `https://raw.githubusercontent.com/Real-Dev-Squad/website-static/main`;
 const getMembersURL = `${baseURL}/members`;
 const cloudinaryImageUrl = `https://res.cloudinary.com/realdevsquad/image/upload`;
 const getUserProfileSelf = `${baseURL}/users/self`;
-
-/**
- *
- * @param {string} rdsId
- */
-const getImgURL = (rdsId, img) => `${imgBaseURL}/members/${rdsId}/${img}`;
 
 /**
  *
@@ -47,7 +40,6 @@ const getArchiveMemberURL = (rdsId) =>
   `${baseURL}/members/archiveMembers/${rdsId}`;
 
 export {
-  getImgURL,
   getMembersDataURL,
   getContributionsURL,
   getMembersURL,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,10 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 import PropTypes from 'prop-types';
-import {
-  getMembersURL,
-  getImgURL,
-  getCloudinaryImgURL,
-} from '@helper-functions/urls';
+import { getMembersURL, getCloudinaryImgURL } from '@helper-functions/urls';
 import fetch from 'cross-fetch';
 import HomePage from '@components/pages';
 import Layout from '@components/layout';
@@ -37,9 +33,6 @@ const Index = ({ membersArr, newMembersArr, errorMsg }) => {
 export async function getServerSideProps(context) {
   context.res.setHeader('Cache-Control', `max-age=${CACHE_MAX_AGE}`);
   const membersArray = [];
-  const {
-    query: { dev },
-  } = context;
   try {
     const res = await fetch(getMembersURL);
     if (res.status !== 200) {
@@ -50,13 +43,12 @@ export async function getServerSideProps(context) {
     const { members } = await res.json();
 
     for (const memberData of members) {
-      const img_url =
-        !!dev && memberData.picture
-          ? getCloudinaryImgURL(
-              memberData.picture.publicId,
-              `${WIDTH_200PX},${HEIGHT_200PX}`
-            )
-          : getImgURL(memberData.username, 'img.png');
+      const img_url = memberData.picture
+        ? getCloudinaryImgURL(
+            memberData.picture.publicId,
+            `${WIDTH_200PX},${HEIGHT_200PX}`
+          )
+        : '/images/Avatar.png';
       membersArray.push({
         ...memberData,
         img_url,


### PR DESCRIPTION
### What is the change?

Added the logic to fetch members' images from Cloudinary and not from the static repository because we were making too many requests to fetch images for each member.

### Is it a bug?

- No

### \*Dev Tested?

- [ ] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [ ] Web

#### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox

### Before / After Change Screenshots

> For visual or interaction changes. Can be video / screenshot.

![Screenshot 2021-12-27 at 9 26 28 PM](https://user-images.githubusercontent.com/29303618/147487923-106d6623-30a1-4287-927b-36fba0f33e40.png)

![Screenshot 2021-12-27 at 9 28 07 PM](https://user-images.githubusercontent.com/29303618/147487983-70554377-7690-4079-a922-89bb5fd4902a.png)
