### PR TITLE
Fixed bug with Archive Member functionality

### DIFF
--- a/src/components/member-role-update/index.js
+++ b/src/components/member-role-update/index.js
@@ -4,7 +4,7 @@ import Modal from '@components/UI/modal/index';
 import { userContext } from '@store/user/user-context';
 import Spinner from '@components/UI/spinner';
 import classNames from './member-role-update.module.scss';
-import { moveToMember } from '../../helper-functions/action-handlers';
+import { archiveMember, moveToMember } from '../../helper-functions/action-handlers';
 
 const MemberRoleUpdate = () => {
   const {
@@ -26,7 +26,7 @@ const MemberRoleUpdate = () => {
       setUpdateStatus('Some error occured, please contact admin');
     }
   };
-  const archiveMember = async (user) => {
+  const archiveTheMember = async (user) => {
     setIsUpdating(true);
     const { status } = await archiveMember(user);
     setIsUpdating(false);
@@ -51,7 +51,7 @@ const MemberRoleUpdate = () => {
         <button
           className={classNames.moveToMember}
           type="button"
-          onClick={() => archiveMember(selectedMember)}
+          onClick={() => archiveTheMember(selectedMember)}
         >
           Archive Member
         </button>


### PR DESCRIPTION
### What is the change?

* **archiveMember** function was invoked infinitely. I modified the function name to a different one.
* [Ticket Link](https://github.com/Real-Dev-Squad/website-members/issues/337)

### Is it bug?
* Yes, It's a bug

- Steps to repro -> The member should be archived when clicked on the **Archive Member** button
- Expected ->  The member should  be archived and return a success Message
- Actual -> The spinner is infinitely spinning, because of the bug

### \*Dev Tested?

- [ ] Yes
- [x] No

**Reasons for not testing** :
* I got CORS error when I tried to invoke the **archiveMember** endpoint
* It is a SuperUser functionality

