### PR TITLE
Remove RDS logo from Home page

### DIFF
--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -36,11 +36,6 @@ const Home = () => {
     >
       {dev && <UserProfile />}
       {dev && <SearchBox />}
-      <img
-        className={styles.img}
-        src="/images/Real-Dev-Squad@1x.png"
-        alt="real-dev squad"
-      />
       <h1 className={styles.heading}>Designers</h1>
       <Designers />
       <h1 className={styles.heading}>{`${BRAND_NAME} ${MEMBERS_TITLE}`}</h1>


### PR DESCRIPTION
### What is the change?

Removal of RDS logo from Home page to replace with members of the week feature.

### Is it bug?

No

### \*Dev Tested?

 Yes


### \*Tested on:

#### Platforms

- [x] Web

#### Browsers

- [x] Chrome
- [ ] Safari
- [ ] Firefox

### Before / After Change Screenshots
Before:
![image](https://user-images.githubusercontent.com/79807326/162253360-f7fd0618-5d5c-4727-869b-0185ffa349cb.png)

After:
![image](https://user-images.githubusercontent.com/79807326/162253237-1e4c73a0-1b6c-4683-ad6d-e1e0115319ee.png)


> For visual or interaction changes. Can be video / screenshot.
