### PR TITLE
fix broken social media link

### DIFF
--- a/src/components/social-media-icon/social-media.constant.js
+++ b/src/components/social-media-icon/social-media.constant.js
@@ -2,12 +2,12 @@ const iconMapper = {
   twitter_id: {
     alt: 'twitter',
     src: '/icons/twitter.png',
-    href: '//twitter.com/',
+    href: '//twitter.com',
   },
   github_id: {
     alt: 'github',
     src: '/icons/github.png',
-    href: '//github.com/',
+    href: '//github.com',
   },
   instagram_id: {
     alt: 'instagram',
@@ -17,7 +17,7 @@ const iconMapper = {
   linkedin_id: {
     alt: 'linkedIn',
     src: '/icons/linkedin.png',
-    href: '//linkedin.com/in/',
+    href: '//linkedin.com/in',
   },
 };
 


### PR DESCRIPTION
### What is the change?

removed extra slashes in media URL to fix broken links, this closes #386

### \*Dev Tested?

- [x] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [x] Web

#### Browsers

- [ ] Chrome
- [ ] Safari
- [x] Firefox
