### PR TITLE
fix: :hammer: headings for mobile screens

### DIFF
--- a/src/components/member-profile/member-profile.module.scss
+++ b/src/components/member-profile/member-profile.module.scss
@@ -217,4 +217,8 @@
   .container {
     width: 100%;
   }
+
+  .card h2 {
+    font-size: 28px;
+  }
 }


### PR DESCRIPTION
Closes #383

### What's the change:
 - Fixed the `font size` of headers. 
 - Rest of the layout looks fine on mobile screens as well as tablets (screenshots are attached below).

## Before:
![image](https://user-images.githubusercontent.com/35677839/178018189-17d5a439-e1a0-4111-b064-a4fe76d2c642.png)

![image](https://user-images.githubusercontent.com/35677839/178018521-5a938a2d-d9e1-42bf-8735-ec97d50221b1.png)


## After:
![image](https://user-images.githubusercontent.com/35677839/178018726-c19ed8ba-02de-4eed-a151-7e57ee971ba0.png)

![image](https://user-images.githubusercontent.com/35677839/178018541-43d61a0d-8f1f-405e-876f-1ee530f4330d.png)

@ankushdharkar Please review this PR. Thank you.


