### PR TITLE
fix: Allow superuser ONLY to see the profile page of non-members

### DIFF
--- a/src/pages/[id]/index.js
+++ b/src/pages/[id]/index.js
@@ -39,7 +39,7 @@ const MemberProfile = ({ imageLink, user, contributions, errorMessage }) => {
     return <NotFound errorMsg={errorMessage} />;
   }
 
-  if (!user.isMember && !isSuperUserMode) {
+  if (!user.roles?.member && !isSuperUserMode) {
     return <NotFound errorMsg="Member not found" />;
   }
 

--- a/src/pages/[id]/index.js
+++ b/src/pages/[id]/index.js
@@ -19,8 +19,10 @@ import {
   HEIGHT_40PX,
 } from '@constants/profile-image';
 import { useEffect, useState } from 'react';
+import { userContext } from '@store/user/user-context';
 
 const MemberProfile = ({ imageLink, user, contributions, errorMessage }) => {
+  const { isSuperUserMode } = userContext();
   const [activeTasksData, setActiveTasksData] = useState([]);
   const router = useRouter();
   const { id } = router.query;
@@ -35,6 +37,10 @@ const MemberProfile = ({ imageLink, user, contributions, errorMessage }) => {
 
   if (errorMessage) {
     return <NotFound errorMsg={errorMessage} />;
+  }
+
+  if (!user.isMember && !isSuperUserMode) {
+    return <NotFound errorMsg="Member not found" />;
   }
 
   const { first_name = '', last_name = '' } = user;


### PR DESCRIPTION
### What is the change?
Non-member profile pages can be viewed from anyone. Only super users should be able to view these profiles.
Issue: #367 

### Is it bug?
Yes

- Steps to repro
Visit any non-member profile page (example: https://members.realdevsquad.com/dhanush_kumar027) 

- Expected
Non super users should not be able to view the non-member profile pages

- Actual
Non-member profile pages are visible to everyone

### \*Dev Tested?

- [X] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [X] Web

#### Browsers

- [X] Chrome
- [ ] Safari
- [X] Firefox

### Before:
Anyone can view non-member profile page
![Non-member profile](https://user-images.githubusercontent.com/80971056/178313689-a6c86490-254c-4c36-9061-abab9514c440.png)

### After:
Non super-users cannot access non-member profile
![Non-member profile 404](https://user-images.githubusercontent.com/80971056/178313679-ed9ad895-ca1e-4f93-94fc-114f7ceec210.png)

Non super-users can access member profile
![Member profile](https://user-images.githubusercontent.com/80971056/178313698-7b75f696-3285-4478-909a-3388e6415d8e.png)

