### PR TITLE
add Checks for Super User while viewing Non Members Pages

### DIFF
--- a/src/components/not-found-page/index.js
+++ b/src/components/not-found-page/index.js
@@ -1,10 +1,6 @@
 import classNames from '@components/not-found-page/not-found-page.module.scss';
-import { membersContext } from '@store/members/members-context';
 
-const Index = () => {
-  const {
-    state: { errorMsg },
-  } = membersContext();
+const Index = ({ errorMsg }) => {
   return (
     <div className={classNames.fullPageContainer}>
       <img

--- a/src/constants/error-messages.js
+++ b/src/constants/error-messages.js
@@ -1,0 +1,1 @@
+export const unAuthorizedPageViewError = 'Unauthorized to view this page.';

--- a/src/pages/[id]/index.js
+++ b/src/pages/[id]/index.js
@@ -31,9 +31,7 @@ const MemberProfile = ({ imageLink, user, contributions, errorMessage }) => {
     return <NotFound errorMsg={errorMessage} />;
   }
   if (!user.roles?.member && !isSuperUserMode) {
-    return (
-      <NotFound errorMsg="You dont have the necassary permissions to view this page." />
-    );
+    return <NotFound errorMsg="Unauthorized to view this page." />;
   }
 
   const fillActiveTasksArray = async () => {

--- a/src/pages/[id]/index.js
+++ b/src/pages/[id]/index.js
@@ -12,13 +12,14 @@ import Profile from '@components/member-profile';
 import NotFound from '@components/not-found-page';
 import Layout from '@components/layout';
 import { CACHE_MAX_AGE } from '@constants/cache-max-age.js';
+import { unAuthorizedPageViewError } from '@constants/error-messages';
 import {
   WIDTH_200PX,
   WIDTH_40PX,
   HEIGHT_200PX,
   HEIGHT_40PX,
 } from '@constants/profile-image';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { userContext } from '@store/user/user-context';
 
 const MemberProfile = ({ imageLink, user, contributions, errorMessage }) => {
@@ -31,10 +32,10 @@ const MemberProfile = ({ imageLink, user, contributions, errorMessage }) => {
     return <NotFound errorMsg={errorMessage} />;
   }
   if (!user.roles?.member && !isSuperUserMode) {
-    return <NotFound errorMsg="Unauthorized to view this page." />;
+    return <NotFound errorMsg={unAuthorizedPageViewError} />;
   }
 
-  const fillActiveTasksArray = async () => {
+  const fillActiveTasksArray = useCallback(async () => {
     const tasksURL = getActiveTasksURL(id);
     try {
       const tasksResponse = await fetch(tasksURL);
@@ -43,11 +44,11 @@ const MemberProfile = ({ imageLink, user, contributions, errorMessage }) => {
     } catch {
       setActiveTasksData([]);
     }
-  };
+  }, [id]);
 
   useEffect(() => {
     fillActiveTasksArray();
-  }, [id]);
+  }, [fillActiveTasksArray]);
 
   const { first_name = '', last_name = '' } = user;
   const memberName = `${first_name} ${last_name} | Member Real Dev Squad`;


### PR DESCRIPTION
### What is the change?
Issue: https://github.com/Real-Dev-Squad/website-members/issues/367
- [x] Adds a check for Super User while viewing pages of Non-Members. Only Super User can view the Non-Members Page.
- [x] Adds a check for users that do not exist.

### Is it a bug?
 Yes

- Steps to repro
- Expected
- Actual

### \*Dev Tested?

- [x] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [x] Web

#### Browsers

- [x] Chrome
- [ ] Safari
- [ ] Firefox

### Before / After Change Screenshots
Before Anyone can view non-member profile page
![image](https://user-images.githubusercontent.com/97341921/183294176-de631035-2906-4950-bcb5-07aaef65fac6.png)

After:
Non super-users cannot access non-member profile
![image](https://user-images.githubusercontent.com/97341921/184188652-23d7e01c-3aae-4e62-91ca-8349359dc55d.png)



> For visual or interaction changes. Can be video / screenshot.
