### PR TITLE
Make New Users Profile clickable for SuperUsers

### DIFF
--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -34,7 +34,7 @@ const Home = () => {
         setIsOptionKey(false);
       }}
     >
-      {dev && <UserProfile />}
+      <UserProfile />
       {dev && <SearchBox />}
       <h1 className={styles.heading}>Designers</h1>
       <Designers />

--- a/src/components/member-card/card.module.scss
+++ b/src/components/member-card/card.module.scss
@@ -14,6 +14,10 @@
   height: 50px;
 }
 
+.removedPointerEvent {
+  pointer-events: none;
+}
+
 .nameOfPerson {
   padding: 10px 10px 0 10px;
   font-size: 1.43rem;

--- a/src/components/member-card/card.module.scss
+++ b/src/components/member-card/card.module.scss
@@ -14,7 +14,7 @@
   height: 50px;
 }
 
-.removedPointerEvent {
+.newUsers {
   pointer-events: none;
 }
 

--- a/src/components/member-card/index.js
+++ b/src/components/member-card/index.js
@@ -41,7 +41,7 @@ const Card = ({ developerInfo, isOptionKey }) => {
       onMouseLeave={() => {
         setShowSettings(false);
       }}
-      className={isMember ? [] : classNames.removedPointerEvent}
+      className={isMember ? [] : classNames.newUsers}
     >
       {dev && (
         <SuperUserOptions username={username} showSettings={showSettings} />

--- a/src/components/member-card/index.js
+++ b/src/components/member-card/index.js
@@ -41,6 +41,7 @@ const Card = ({ developerInfo, isOptionKey }) => {
       onMouseLeave={() => {
         setShowSettings(false);
       }}
+      className={isMember ? [] : classNames.removedPointerEvent}
     >
       {dev && (
         <SuperUserOptions username={username} showSettings={showSettings} />

--- a/src/components/new-members/index.js
+++ b/src/components/new-members/index.js
@@ -5,19 +5,43 @@ import styles from '@components/new-members/new-members.module.scss';
 import { membersContext } from '@store/members/members-context';
 import { searchMemberContext } from '@store/search-members/searchMembers-context';
 import { searchMembers } from '@helper-functions/search-members';
+import Link from 'next/link';
+import { userContext } from '@store/user/user-context';
 
 // returns card which shows details of new member
-const renderNewMember = (newMember, isOptionKey) => (
-  <div className={styles.containerForNewMember}>
-    <Card
-      developerInfo={newMember}
-      isMember={false}
-      isOptionKey={isOptionKey}
-    />
-  </div>
-);
+const renderNewMember = (newMember, isOptionKey) => {
+  return (
+    <div className={styles.containerForNewMember}>
+      <Card
+        developerInfo={newMember}
+        isMember={false}
+        isOptionKey={isOptionKey}
+      />
+    </div>
+  );
+};
+
+const renderNewMemberAsClickable = (newMember, isOptionKey) => {
+  return (
+    <Link
+      prefetch={false}
+      href={{
+        pathname: '/[id]',
+        query: {
+          first_name: `${newMember.first_name || ''}`,
+          last_name: `${newMember.last_name || ''}`,
+        },
+      }}
+      as={`/${newMember.username}`}
+      key={newMember.username}
+    >
+      {renderNewMember(newMember, isOptionKey)}
+    </Link>
+  );
+};
 
 const NewMemberList = ({ isOptionKey }) => {
+  const { isSuperUser } = userContext();
   const {
     state: { newMembers },
   } = membersContext();
@@ -28,7 +52,9 @@ const NewMemberList = ({ isOptionKey }) => {
       <div className={styles.container}>
         {filterMembers.map((newMember) => (
           <React.Fragment key={newMember.id}>
-            {renderNewMember(newMember, isOptionKey)}
+            {isSuperUser && isOptionKey
+              ? renderNewMemberAsClickable(newMember, isOptionKey)
+              : renderNewMember(newMember, isOptionKey)}
           </React.Fragment>
         ))}
       </div>

--- a/src/components/new-members/index.js
+++ b/src/components/new-members/index.js
@@ -9,7 +9,7 @@ import Link from 'next/link';
 import { userContext } from '@store/user/user-context';
 
 // returns card which shows details of new member
-const renderNewMember = (newMember, isOptionKey) => {
+const renderNewUserCard = (newMember, isOptionKey) => {
   return (
     <div className={styles.containerForNewMember}>
       <Card
@@ -21,23 +21,26 @@ const renderNewMember = (newMember, isOptionKey) => {
   );
 };
 
-const renderNewMemberAsClickable = (newMember, isOptionKey) => {
-  return (
-    <Link
-      prefetch={false}
-      href={{
-        pathname: '/[id]',
-        query: {
-          first_name: `${newMember.first_name || ''}`,
-          last_name: `${newMember.last_name || ''}`,
-        },
-      }}
-      as={`/${newMember.username}`}
-      key={newMember.username}
-    >
-      {renderNewMember(newMember, isOptionKey)}
-    </Link>
-  );
+const renderNewUsers = (newMember, isOptionKey, isSuperUser) => {
+  if (isSuperUser && isOptionKey) {
+    return (
+      <Link
+        prefetch={false}
+        href={{
+          pathname: '/[id]',
+          query: {
+            first_name: `${newMember.first_name || ''}`,
+            last_name: `${newMember.last_name || ''}`,
+          },
+        }}
+        as={`/${newMember.username}`}
+        key={newMember.username}
+      >
+        {renderNewUserCard(newMember, isOptionKey)}
+      </Link>
+    );
+  }
+  return renderNewUserCard(newMember, isOptionKey);
 };
 
 const NewMemberList = ({ isOptionKey }) => {
@@ -52,9 +55,7 @@ const NewMemberList = ({ isOptionKey }) => {
       <div className={styles.container}>
         {filterMembers.map((newMember) => (
           <React.Fragment key={newMember.id}>
-            {isSuperUser && isOptionKey
-              ? renderNewMemberAsClickable(newMember, isOptionKey)
-              : renderNewMember(newMember, isOptionKey)}
+            {renderNewUsers(newMember, isOptionKey, isSuperUser)}
           </React.Fragment>
         ))}
       </div>

--- a/src/components/new-members/index.js
+++ b/src/components/new-members/index.js
@@ -21,17 +21,14 @@ const renderNewUserCard = (newMember, isOptionKey) => {
   );
 };
 
-const renderNewUsers = (newMember, isOptionKey, isSuperUser) => {
+const renderNewUser = (newMember, isOptionKey) => {
+  const { isSuperUser } = userContext();
   if (isSuperUser && isOptionKey) {
     return (
       <Link
         prefetch={false}
         href={{
           pathname: '/[id]',
-          query: {
-            first_name: `${newMember.first_name || ''}`,
-            last_name: `${newMember.last_name || ''}`,
-          },
         }}
         as={`/${newMember.username}`}
         key={newMember.username}
@@ -44,7 +41,6 @@ const renderNewUsers = (newMember, isOptionKey, isSuperUser) => {
 };
 
 const NewMemberList = ({ isOptionKey }) => {
-  const { isSuperUser } = userContext();
   const {
     state: { newMembers },
   } = membersContext();
@@ -55,7 +51,7 @@ const NewMemberList = ({ isOptionKey }) => {
       <div className={styles.container}>
         {filterMembers.map((newMember) => (
           <React.Fragment key={newMember.id}>
-            {renderNewUsers(newMember, isOptionKey, isSuperUser)}
+            {renderNewUser(newMember, isOptionKey)}
           </React.Fragment>
         ))}
       </div>

--- a/src/components/user-profile/index.js
+++ b/src/components/user-profile/index.js
@@ -39,13 +39,13 @@ const UserProfile = () => {
     );
   };
 
-  if (!isLoading && user)
+  if (!isLoading && isSuperUser && user)
     return (
       <div className={classNames.superUserOptions}>
         <p>
           Hello {user.first_name} {user.last_name}
         </p>
-        {isSuperUser && showSuperUserOptions()}
+        {showSuperUserOptions()}
       </div>
     );
   return <div />;


### PR DESCRIPTION
### What is the change?
This is a stacked PR & should be merged after PR  https://github.com/Real-Dev-Squad/website-members/pull/410
closes #407

- [x] for superUser make the nonmembers or new members' profile clickable 
- [x] This feature will work once superUser holds the alt key and click on their profile. 

### Is it bug?
No

- Steps to repro
- Expected
- Actual

### \*Dev Tested?

- [x] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [x] Web

#### Browsers

- [x] Chrome
- [ ] Safari
- [ ] Firefox

### Before / After Change Screenshots

> For visual or interaction changes. Can be video / screenshot.
