### PR TITLE
fix: removed Math.random() from src of <motion.img/>

### DIFF
--- a/src/components/member-card/index.js
+++ b/src/components/member-card/index.js
@@ -47,9 +47,7 @@ const Card = ({ developerInfo, isOptionKey }) => {
       )}
       <motion.img
         layoutId={username}
-        src={
-          isMember ? `${img_url}?${Math.random() * 100}` : '/images/Avatar.png'
-        }
+        src={isMember ? `${img_url}` : '/images/Avatar.png'}
         onError={brokenImageHandler}
         className={
           isMember ? classNames.imgContainer : classNames.imgContainerNewMember


### PR DESCRIPTION
### What is the change?

Previously, Math.random() was concatenated with the image URL query, which served no purpose in my opinion. The downside of concatenating Math.random() is that each time we navigate to a different page and return, a new number is generated and concatenated with the image URL. When react detects that an asset has not yet been downloaded, it sends a request for the new assets, resulting in all images being downloaded repeatedly when navigating back and forth.
Closes #423 

### Is it bug?

- Steps to repro - Visit [https://members.realdevsquad.com/](url), click on any member, and check the network tab.
- Expected - Only the image of clicked member has to be downloaded.
- Actual - All the images are being downloaded irrespective of the clicked member 

### Before / After Change Screenshots

**Before Changes - When clicking on a particular member**
![image](https://user-images.githubusercontent.com/75324135/188139921-5403b949-6922-4acb-9067-f7d935c9db3d.png)

**After Changes**
Before clicking on a particular member, the total number of requests is 29.
![image](https://user-images.githubusercontent.com/75324135/188140678-e2fae8d3-7fc2-4d2a-a9df-c0c85a63ca70.png)

After clicking on a particular member, the total number of requests is 30. Which means the image of only the clicked user was downloaded.
![image](https://user-images.githubusercontent.com/75324135/188140907-09c15f3f-9b6d-43d9-98f4-c662340681ec.png)





