### PR TITLE
Display new users profile picture

### DIFF
--- a/src/components/member-card/index.js
+++ b/src/components/member-card/index.js
@@ -47,7 +47,7 @@ const Card = ({ developerInfo, isOptionKey }) => {
       )}
       <motion.img
         layoutId={username}
-        src={isMember ? `${img_url}` : '/images/Avatar.png'}
+        src={img_url || '/images/Avatar.png'}
         onError={brokenImageHandler}
         className={
           isMember ? classNames.imgContainer : classNames.imgContainerNewMember


### PR DESCRIPTION
## Problem Description
On the member's site, the section for new users does not show the profile pictures.

### Issue related to problem #444 
This branch closes #444 

### Why was the issue raised
- It caused inconvenience in checking out the users and finding the correct ones in case of the same names.
- it also degraded the user experience by seeing a bunch of dummy avatars.

### Problem found in:
The problem was found in the `member-card` component where we were checking that if the user is a member then show the profile picture else show the default avatar. 

### What is the change?
Removed the ternary operator in the `member-card` component's `motion.img` tag to show profile pic if available or show default avatar.

### Is it a bug?
It can be considered a bug, Earlier we were supposed to show the profile pictures of the members only, but as we grew we now have a necessity to show the profile picture of the users as well.

### \*Dev Tested?

- [x] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [x] Web

#### Browsers

- [x] Chrome
- [ ] Safari
- [ ] Firefox

### Screenshot before the change:
![image](https://user-images.githubusercontent.com/57758447/195034285-f7e02f8a-aeae-41d1-925a-b35d4954350b.png)

### Screenshot after the change:
![image](https://user-images.githubusercontent.com/57758447/195034505-63b38a08-048f-483c-98be-2986473db5a2.png)

