### PR TITLE
fixed the 404 page flash issue

### DIFF
--- a/src/pages/[id]/index.js
+++ b/src/pages/[id]/index.js
@@ -22,9 +22,11 @@ import {
 import { useEffect, useState } from 'react';
 import { userContext } from '@store/user/user-context';
 import { UserTasksApi } from '@api/UserTasksApi';
+import Spinner from '@components/UI/spinner';
 
 const MemberProfile = ({ imageLink, user, contributions, errorMessage }) => {
-  const { isSuperUser, userApiCalled, setUserPrivileges } = userContext();
+  const { isSuperUser, userApiCalled, setUserPrivileges, isLoading } =
+    userContext();
   const [activeTasksData, setActiveTasksData] = useState([]);
   const router = useRouter();
   const { id } = router.query;
@@ -32,6 +34,10 @@ const MemberProfile = ({ imageLink, user, contributions, errorMessage }) => {
   useEffect(() => {
     UserTasksApi.getAll(id).then((listTasks) => setActiveTasksData(listTasks));
   }, [id]);
+
+  if (isLoading) {
+    return <Spinner />;
+  }
 
   if (errorMessage) {
     return <NotFound errorMsg={errorMessage} />;

--- a/src/store/user/user-context.js
+++ b/src/store/user/user-context.js
@@ -6,6 +6,7 @@ const UserContext = createContext();
 
 export const UserContextProvider = ({ children }) => {
   const [user, setUser] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
   const [isSuperUser, setIsSuperUser] = useState(false);
   const [showMemberRoleUpdateModal, setShowMemberRoleUpdateModal] =
     useState(false);
@@ -13,10 +14,12 @@ export const UserContextProvider = ({ children }) => {
   const [userApiCalled, setUserApiCalled] = useState(false);
 
   const setUserPrivileges = useCallback(async () => {
+    setIsLoading(true);
     const userData = await UserData.get();
     setUserApiCalled(true);
     setUser(userData);
     setIsSuperUser(Boolean(userData?.roles?.super_user));
+    setIsLoading(false);
   }, [setUserApiCalled, setIsSuperUser, setUser]);
 
   const initialUserContext = {
@@ -24,6 +27,7 @@ export const UserContextProvider = ({ children }) => {
     isSuperUser,
     selectedMember,
     showMemberRoleUpdateModal,
+    isLoading,
     setIsSuperUser,
     setUser,
     setSelectedMember,
@@ -31,6 +35,7 @@ export const UserContextProvider = ({ children }) => {
     userApiCalled,
     setUserApiCalled,
     setUserPrivileges,
+    setIsLoading,
   };
 
   return (


### PR DESCRIPTION
closes #428 

### What was the issue?
The super user context was getting set after some time when the page loads which is why it was giving a flash of 404 error page, added an `isLoading` context which gets set to true when the `setUserPriviledge` function call is made, and it shows a spinner in the whole page while the API call is getting made.

### Is it bug?
Yes

### \*Dev Tested?

- [X] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [X] Web

#### Browsers

- [X] Chrome
- [ ] Safari
- [ ] Firefox