### PR TITLE
show relevant options for buttons

### DIFF
--- a/src/components/member-card/index.js
+++ b/src/components/member-card/index.js
@@ -33,7 +33,11 @@ const Card = ({ developerInfo }) => {
       onMouseEnter={() => setShowSettings(true)}
       onMouseLeave={() => setShowSettings(false)}
     >
-      <SuperUserOptions username={username} showSettings={showSettings} />
+      <SuperUserOptions
+        username={username}
+        showSettings={showSettings}
+        isMember={isMember}
+      />
       <motion.img
         layoutId={username}
         src={img_url || '/images/Avatar.png'}

--- a/src/components/member-card/super-user-options/container.js
+++ b/src/components/member-card/super-user-options/container.js
@@ -3,12 +3,18 @@ import { useKeyboardContext } from '@store/keyboard/context';
 import { userContext } from '@store/user/user-context';
 import SuperUserOptions from '.';
 
-const ShowSuperUserOptionContainer = ({ showSettings, username }) => {
+const ShowSuperUserOptionContainer = ({ showSettings, username, isMember }) => {
   const { isOptionKeyPressed } = useKeyboardContext();
   const { isSuperUser } = userContext();
 
   if (isOptionKeyPressed && isSuperUser) {
-    return <SuperUserOptions username={username} showSettings={showSettings} />;
+    return (
+      <SuperUserOptions
+        username={username}
+        showSettings={showSettings}
+        isMember={isMember}
+      />
+    );
   }
   return null;
 };

--- a/src/components/member-card/super-user-options/index.js
+++ b/src/components/member-card/super-user-options/index.js
@@ -2,13 +2,15 @@ import React from 'react';
 import classNames from '@components/member-card/card.module.scss';
 import { userContext } from '@store/user/user-context';
 
-const SuperUserOptions = ({ showSettings, username }) => {
-  const { setShowMemberRoleUpdateModal, setSelectedMember } = userContext();
+const SuperUserOptions = ({ showSettings, username, isMember }) => {
+  const { setShowMemberRoleUpdateModal, setSelectedMember, setIsUserMember } =
+    userContext();
 
   const showModal = (e) => {
     e.preventDefault();
     setShowMemberRoleUpdateModal(true);
     setSelectedMember(username);
+    setIsUserMember(isMember);
   };
 
   return (

--- a/src/components/member-role-update/index.js
+++ b/src/components/member-role-update/index.js
@@ -14,6 +14,7 @@ const MemberRoleUpdate = () => {
     showMemberRoleUpdateModal,
     setShowMemberRoleUpdateModal,
     selectedMember,
+    isUserMember,
   } = userContext();
 
   const [isUpdating, setIsUpdating] = useState(false);
@@ -41,6 +42,22 @@ const MemberRoleUpdate = () => {
   };
 
   const renderPromoteButton = () => {
+    if (isUserMember) {
+      return (
+        <>
+          <button
+            className={classNames.moveToMember}
+            type="button"
+            onClick={() => archiveTheMember(selectedMember)}
+          >
+            Archive Member
+          </button>
+          <br />
+          <p>{updateStatus}</p>
+        </>
+      );
+    }
+
     return (
       <>
         <button

--- a/src/store/user/user-context.js
+++ b/src/store/user/user-context.js
@@ -12,6 +12,7 @@ export const UserContextProvider = ({ children }) => {
     useState(false);
   const [selectedMember, setSelectedMember] = useState(null);
   const [userApiCalled, setUserApiCalled] = useState(false);
+  const [isUserMember, setIsUserMember] = useState(true);
 
   const setUserPrivileges = useCallback(async () => {
     setIsLoading(true);
@@ -36,6 +37,8 @@ export const UserContextProvider = ({ children }) => {
     setUserApiCalled,
     setUserPrivileges,
     setIsLoading,
+    isUserMember,
+    setIsUserMember,
   };
 
   return (


### PR DESCRIPTION
**What is the change?**
when the super clicks on the setting button to update the role of an existing member he should see only the archive member option.
when he clicks on non-member he should see promote to member and archive button.

**Is it a bug?**
No

***Dev** **Tested?**
 

- [x] Yes

 No

***Tested** **on:**
**Platforms**

- [x] Web

**Browsers**
 

- [x] Chrome

 

- [ ] Safari

 

- [ ] Firefox

**Before Change Screenshots**
Before:
https://www.loom.com/share/cd25966dbd9943da866b34d8efe85b94

After:
https://www.loom.com/share/2a58206fc7ba452aab4aa2e2822db5de