### PR TITLE
aligned last row new  users to left

### DIFF
--- a/src/components/new-members/new-members.module.scss
+++ b/src/components/new-members/new-members.module.scss
@@ -1,8 +1,9 @@
 .container {
-  display: flex;
-  flex-wrap: wrap;
   width: 100%;
   margin: 40px auto 40px;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, 160px);
   justify-content: center;
 }
 


### PR DESCRIPTION
### What is the change?

Provide a small description of what did you change and provide the reference to the issue ticket.

The users in last row were aligned in the middle so it was required to be left-aligned.

### Is it bug?

- Steps to repro
- Expected
- Actual

### \*Dev Tested?

- [ x ] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [ ] Web

#### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox

### Before / After Change Screenshots

> For visual or interaction changes. Can be video / screenshot.
