### PR TITLE
Fix error for admin, on opening setting model, it going to users page

### DIFF
--- a/src/components/member-card/super-user-options/index.js
+++ b/src/components/member-card/super-user-options/index.js
@@ -7,6 +7,7 @@ const SuperUserOptions = ({ showSettings, username }) => {
 
   const showModal = (e) => {
     e.preventDefault();
+    e.stopPropagation();
     setShowMemberRoleUpdateModal(true);
     setSelectedMember(username);
   };


### PR DESCRIPTION
### What is the change?
Added e.stopPropogaion() in show model.

###Bug
When superuser holds the option key and clicks on the setting option, then the app goes to the user page, instead of opening super user options model



### \*Dev Tested?

- [x] Yes
- [ ] No

