### PR TITLE
fix: if there are no tasks in any of the category then dropdown will …

### DIFF
--- a/src/components/member-profile/contribution-type/index.js
+++ b/src/components/member-profile/contribution-type/index.js
@@ -28,9 +28,10 @@ const renderActiveTasks = (tasks) => {
 const ContributionType = (props) => {
   const { fullName, type, imageLink, contributions, devUser, tasks } = props;
   const [showMoreContent, setShowMoreContent] = useState(false);
+  const isContribution = type === 'Noteworthy' || type === 'All';
 
   useEffect(() => {
-    if (type === 'Noteworthy' || type === 'All') {
+    if (isContribution) {
       setShowMoreContent(contributions.length > 0);
       return;
     }
@@ -38,7 +39,7 @@ const ContributionType = (props) => {
   }, [tasks.length, contributions.length]);
 
   const showMoreContentHandler = () => {
-    if (type === 'Noteworthy' || type === 'All') {
+    if (isContribution) {
       if (contributions.length > 0) {
         setShowMoreContent(!showMoreContent);
       }

--- a/src/components/member-profile/contribution-type/index.js
+++ b/src/components/member-profile/contribution-type/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-array-index-key */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from '@components/member-profile/contribution-type/contributions-type.module.scss';
 import Contribution from '@components/member-profile/contribution/';
@@ -27,11 +27,25 @@ const renderActiveTasks = (tasks) => {
 
 const ContributionType = (props) => {
   const { fullName, type, imageLink, contributions, devUser, tasks } = props;
+  const [showMoreContent, setShowMoreContent] = useState(false);
 
-  const [showMoreContent, setShowMoreContent] = useState(true);
+  useEffect(() => {
+    if (type === 'Noteworthy' || type === 'All') {
+      setShowMoreContent(contributions.length > 0);
+      return;
+    }
+    setShowMoreContent(tasks.length > 0);
+  }, [tasks.length, contributions.length]);
 
   const showMoreContentHandler = () => {
-    setShowMoreContent((prevstate) => !prevstate);
+    if (type === 'Noteworthy' || type === 'All') {
+      if (contributions.length > 0) {
+        setShowMoreContent(!showMoreContent);
+      }
+    }
+    if (tasks.length > 0) {
+      setShowMoreContent(!showMoreContent);
+    }
   };
 
   const showMoreContentClass = showMoreContent

--- a/src/components/member-profile/index.js
+++ b/src/components/member-profile/index.js
@@ -35,6 +35,7 @@ const renderContributionsTypes = (
   tasks
 ) => {
   const { noteworthy, all } = contributions;
+
   return CONTRIBUTIONTYPE.map((type, index) => (
     <ContributionType
       type={type}


### PR DESCRIPTION
…not rotate

### What is the change?

If there are no tasks in particular category dropdown will not rotate

### Is it bug?

- Steps to repro
- Expected
- Actual

### \*Dev Tested?

- [x] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [ ] Web

#### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox

### Before / After Change Screenshots
Before -
![bug](https://user-images.githubusercontent.com/22213872/235519935-81dc266c-1baf-423c-aa1e-65a8d59dfc62.png)

After - 
![fixed (2)](https://user-images.githubusercontent.com/22213872/235519999-9d5f6e30-e8ed-44a2-80a2-bf31c76f28a8.png)

> For visual or interaction changes. Can be video / screenshot.
