### PR TITLE
Provide super user option on member detail page

### DIFF
--- a/src/components/keyboard-handler/index.js
+++ b/src/components/keyboard-handler/index.js
@@ -3,8 +3,11 @@ import { useKeyboardContext } from '@store/keyboard/context';
 import { ALT_KEY } from '@constants/AppConstants';
 
 function isOptionKey(e) {
-  if (e.key === ALT_KEY) e.preventDefault();
-  return e.key === ALT_KEY;
+  if (e.key === ALT_KEY) {
+    e.preventDefault();
+    return true;
+  }
+  return false;
 }
 
 function KeyboardHandler({ children }) {

--- a/src/components/keyboard-handler/index.js
+++ b/src/components/keyboard-handler/index.js
@@ -3,7 +3,7 @@ import { useKeyboardContext } from '@store/keyboard/context';
 import { ALT_KEY } from '@constants/AppConstants';
 
 function isOptionKey(e) {
-  e.preventDefault();
+  if (e.key === ALT_KEY) e.preventDefault();
   return e.key === ALT_KEY;
 }
 

--- a/src/components/keyboard-handler/index.js
+++ b/src/components/keyboard-handler/index.js
@@ -3,6 +3,7 @@ import { useKeyboardContext } from '@store/keyboard/context';
 import { ALT_KEY } from '@constants/AppConstants';
 
 function isOptionKey(e) {
+  e.preventDefault();
   return e.key === ALT_KEY;
 }
 

--- a/src/components/member-profile/index.js
+++ b/src/components/member-profile/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import React, { useRef, useState } from 'react';
+import { useRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import SocialMediaIcon from '@components/social-media-icon';
 import getBadges from '@components/member-profile/mock/get-badges';
@@ -14,6 +15,9 @@ import { KEY_ESC, KEY_TAB } from '@constants/AppConstants';
 import MemberTaskUpdate from '@components/member-task-update';
 import { useTaskContext } from '@store/tasks/tasks-context';
 import { userContext } from '@store/user/user-context';
+import { useKeyboardContext } from '@store/keyboard/context';
+import SuperUserOptions from '@components/member-card/super-user-options';
+import MemberRoleUpdate from '@components/member-role-update';
 
 const renderBadgeImages = (badges) =>
   badges.map((badge) => (
@@ -66,25 +70,28 @@ const Profile = (props) => {
   } = props;
   const { membersData } = props;
   const isMember = Boolean(membersData?.roles?.member);
+
   const memberStatusMessage = isMember
     ? 'User is a Member'
     : 'User is not a Member';
-
+  const { showMemberRoleUpdateModal, isSuperUser } = userContext();
   const socialMedia = [
     'twitter_id',
     'github_id',
     'linkedin_id',
     'instagram_id',
   ];
+  const { query } = useRouter() || { query: { dev: false } };
+  const { dev } = query;
 
   const { showMemberTaskUpdateModal } = useTaskContext();
-  const { isSuperUser } = userContext();
   const fullName = `${first_name} ${last_name}`;
   const memberName = fullName.trim() || '--';
   const rdsUserName = `@${username}`;
 
   const badges = getBadges(username);
-
+  const { isOptionKeyPressed } = useKeyboardContext();
+  const [showSettings, setShowSettings] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const { register, handleSubmit, errors } = useForm();
   const submitBtnRef = useRef(null);
@@ -367,6 +374,11 @@ const Profile = (props) => {
           {children}
         </Modal>
       )}
+      {isSuperUser && (
+        <div id="memberRoleUpdateModal">
+          {showMemberRoleUpdateModal && <MemberRoleUpdate />}
+        </div>
+      )}
       {showMemberTaskUpdateModal && <MemberTaskUpdate />}
       <div className={classNames.container}>
         <div className={(classNames.sidebar, classNames.column)}>
@@ -379,15 +391,33 @@ const Profile = (props) => {
               alt={fullName}
             />
             {isSuperUser && (
-              <div className={classNames.memberStatus}>
-                <img
-                  alt="info icon"
-                  src="icons/info.png"
-                  width={20}
-                  height={20}
-                />
-                <span>{memberStatusMessage}</span>
-              </div>
+              <>
+                <div
+                  className={classNames.memberStatus}
+                  onMouseEnter={() => setShowSettings(true)}
+                  onMouseLeave={() => setShowSettings(false)}
+                >
+                  <img
+                    alt="info icon"
+                    src="icons/info.png"
+                    width={20}
+                    height={20}
+                  />
+                  <span>{memberStatusMessage}</span>
+                  {dev && (
+                    <span style={{ marginLeft: '0.8rem' }}>
+                      {isSuperUser && isOptionKeyPressed && (
+                        <>
+                          <SuperUserOptions
+                            showSettings={showSettings}
+                            username={membersData.username}
+                          />
+                        </>
+                      )}
+                    </span>
+                  )}
+                </div>
+              </>
             )}
 
             <div className={classNames.personalInfo}>

--- a/src/components/member-profile/index.js
+++ b/src/components/member-profile/index.js
@@ -390,34 +390,26 @@ const Profile = (props) => {
               className={classNames.profilePic}
               alt={fullName}
             />
-            {isSuperUser && (
-              <>
-                <div
-                  className={classNames.memberStatus}
-                  onMouseEnter={() => setShowSettings(true)}
-                  onMouseLeave={() => setShowSettings(false)}
-                >
-                  <img
-                    alt="info icon"
-                    src="icons/info.png"
-                    width={20}
-                    height={20}
+            {dev && isSuperUser && isOptionKeyPressed && (
+              <div
+                className={classNames.memberStatus}
+                onMouseEnter={() => setShowSettings(true)}
+                onMouseLeave={() => setShowSettings(false)}
+              >
+                <img
+                  alt="info icon"
+                  src="icons/info.png"
+                  width={20}
+                  height={20}
+                />
+                <span>{memberStatusMessage}</span>
+                <span style={{ marginLeft: '0.8rem' }}>
+                  <SuperUserOptions
+                    showSettings={showSettings}
+                    username={membersData.username}
                   />
-                  <span>{memberStatusMessage}</span>
-                  {dev && (
-                    <span style={{ marginLeft: '0.8rem' }}>
-                      {isSuperUser && isOptionKeyPressed && (
-                        <>
-                          <SuperUserOptions
-                            showSettings={showSettings}
-                            username={membersData.username}
-                          />
-                        </>
-                      )}
-                    </span>
-                  )}
-                </div>
-              </>
+                </span>
+              </div>
             )}
 
             <div className={classNames.personalInfo}>

--- a/src/components/member-profile/index.js
+++ b/src/components/member-profile/index.js
@@ -367,6 +367,8 @@ const Profile = (props) => {
     e.target.src = '/images/Avatar.png';
   };
 
+  const superUserOptionKeyPress = dev && isSuperUser && isOptionKeyPressed;
+
   return (
     <>
       {showModal && (
@@ -390,7 +392,7 @@ const Profile = (props) => {
               className={classNames.profilePic}
               alt={fullName}
             />
-            {dev && isSuperUser && isOptionKeyPressed && (
+            {superUserOptionKeyPress && (
               <div
                 className={classNames.memberStatus}
                 onMouseEnter={() => setShowSettings(true)}

--- a/src/components/member-profile/index.js
+++ b/src/components/member-profile/index.js
@@ -403,7 +403,7 @@ const Profile = (props) => {
                   height={20}
                 />
                 <span>{memberStatusMessage}</span>
-                <span style={{ marginLeft: '0.8rem' }}>
+                <span className={classNames.showSettingsButton}>
                   <SuperUserOptions
                     showSettings={showSettings}
                     username={membersData.username}

--- a/src/components/member-profile/member-profile.module.scss
+++ b/src/components/member-profile/member-profile.module.scss
@@ -216,6 +216,10 @@
   width: 1rem;
 }
 
+.showSettingsButton {
+  margin-left: 0.8rem;
+}
+
 .hidden {
   display: none;
 }

--- a/src/components/member-role-update/index.js
+++ b/src/components/member-role-update/index.js
@@ -26,6 +26,9 @@ const MemberRoleUpdate = () => {
     `${BASE_API_URL}/users/${selectedMember}`
   );
 
+  const member = userData?.user.roles.member;
+  const archived = userData?.user.roles.archived;
+
   const { data: tagData } = useFetch(`${BASE_API_URL}/tags`);
   const { data: levelData } = useFetch(`${BASE_API_URL}/levels`);
 
@@ -54,21 +57,40 @@ const MemberRoleUpdate = () => {
   const renderPromoteButton = () => {
     return (
       <>
-        <button
-          className={classNames.moveToMember}
-          type="button"
-          onClick={() => promoteToMember(selectedMember)}
-        >
-          Promote to Member
-        </button>
-
-        <button
-          className={classNames.moveToMember}
-          type="button"
-          onClick={() => archiveTheMember(selectedMember)}
-        >
-          Archive Member
-        </button>
+        {member ? (
+          <button
+            className={classNames.moveToMember}
+            type="button"
+            onClick={() => promoteToMember(selectedMember)}
+          >
+            Demote Member
+          </button>
+        ) : (
+          <button
+            className={classNames.moveToMember}
+            type="button"
+            onClick={() => promoteToMember(selectedMember)}
+          >
+            Promote to Member
+          </button>
+        )}
+        {archived ? (
+          <button
+            className={classNames.moveToMember}
+            type="button"
+            onClick={() => archiveTheMember(selectedMember)}
+          >
+            Unarchive Member
+          </button>
+        ) : (
+          <button
+            className={classNames.moveToMember}
+            type="button"
+            onClick={() => archiveTheMember(selectedMember)}
+          >
+            Archive Member
+          </button>
+        )}
 
         <br />
 

--- a/src/components/member-role-update/index.js
+++ b/src/components/member-role-update/index.js
@@ -7,10 +7,7 @@ import MemberTagAssign from '@components/member-tag-assign';
 import { BASE_API_URL } from '@constants/AppConstants';
 import useFetch from '@custom-hooks/useFetch';
 import classNames from './member-role-update.module.scss';
-import {
-  archiveMember,
-  moveToMember,
-} from '../../helper-functions/action-handlers';
+import { memberRoleUpdate } from '../../helper-functions/action-handlers';
 
 const MemberRoleUpdate = () => {
   const {
@@ -28,27 +25,61 @@ const MemberRoleUpdate = () => {
 
   const member = userData?.user.roles.member;
   const archived = userData?.user.roles.archived;
-
+  const userId = userData?.user.id;
   const { data: tagData } = useFetch(`${BASE_API_URL}/tags`);
   const { data: levelData } = useFetch(`${BASE_API_URL}/levels`);
 
-  const promoteToMember = async (user) => {
+  const promoteToMember = async (id) => {
     setIsUpdating(true);
-    const { status } = await moveToMember(user);
+    const role = {
+      member: true,
+    };
+    const { status } = await memberRoleUpdate(id, role);
     setIsUpdating(false);
-    if (status === 204) {
-      setUpdateStatus('User moved to member');
+    if (status === 200) {
+      setUpdateStatus('user promoted to a member');
+    } else {
+      setUpdateStatus('some error occured, please contact admin');
+    }
+  };
+
+  const demoteFromMember = async (id) => {
+    setIsUpdating(true);
+    const role = {
+      member: false,
+    };
+    const { status } = await memberRoleUpdate(id, role);
+    setIsUpdating(false);
+    if (status === 200) {
+      setUpdateStatus('user deomoted from member');
+    } else {
+      setUpdateStatus('some error occured, please contact admin');
+    }
+  };
+
+  const archiveTheMember = async (id) => {
+    setIsUpdating(true);
+    const role = {
+      archived: true,
+    };
+    const { status } = await memberRoleUpdate(id, role);
+    setIsUpdating(false);
+    if (status === 200) {
+      setUpdateStatus('user archived!');
     } else {
       setUpdateStatus('Some error occured, please contact admin');
     }
   };
 
-  const archiveTheMember = async (user) => {
+  const unArchiveMember = async (id) => {
     setIsUpdating(true);
-    const { status } = await archiveMember(user);
+    const role = {
+      archived: false,
+    };
+    const { status } = await memberRoleUpdate(id, role);
     setIsUpdating(false);
-    if (status === 204) {
-      setUpdateStatus('User archived!');
+    if (status === 200) {
+      setUpdateStatus('user un-archived!');
     } else {
       setUpdateStatus('Some error occured, please contact admin');
     }
@@ -58,7 +89,7 @@ const MemberRoleUpdate = () => {
     <button
       className={classNames.moveToMember}
       type="button"
-      onClick={() => promoteToMember(selectedMember)}
+      onClick={() => demoteFromMember(userId)}
     >
       Demote Member
     </button>
@@ -66,7 +97,7 @@ const MemberRoleUpdate = () => {
     <button
       className={classNames.moveToMember}
       type="button"
-      onClick={() => promoteToMember(selectedMember)}
+      onClick={() => promoteToMember(userId)}
     >
       Promote to Member
     </button>
@@ -76,7 +107,7 @@ const MemberRoleUpdate = () => {
     <button
       className={classNames.moveToMember}
       type="button"
-      onClick={() => archiveTheMember(selectedMember)}
+      onClick={() => unArchiveMember(userId)}
     >
       Unarchive Member
     </button>
@@ -84,7 +115,7 @@ const MemberRoleUpdate = () => {
     <button
       className={classNames.moveToMember}
       type="button"
-      onClick={() => archiveTheMember(selectedMember)}
+      onClick={() => archiveTheMember(userId)}
     >
       Archive Member
     </button>

--- a/src/components/member-role-update/index.js
+++ b/src/components/member-role-update/index.js
@@ -39,6 +39,7 @@ const MemberRoleUpdate = () => {
       setUpdateStatus('Some error occured, please contact admin');
     }
   };
+
   const archiveTheMember = async (user) => {
     setIsUpdating(true);
     const { status } = await archiveMember(user);
@@ -68,6 +69,7 @@ const MemberRoleUpdate = () => {
         >
           Archive Member
         </button>
+
         <br />
 
         {userData && tagData && levelData && (

--- a/src/components/member-role-update/index.js
+++ b/src/components/member-role-update/index.js
@@ -54,43 +54,47 @@ const MemberRoleUpdate = () => {
     }
   };
 
+  const memberRoleUpdateButton = member ? (
+    <button
+      className={classNames.moveToMember}
+      type="button"
+      onClick={() => promoteToMember(selectedMember)}
+    >
+      Demote Member
+    </button>
+  ) : (
+    <button
+      className={classNames.moveToMember}
+      type="button"
+      onClick={() => promoteToMember(selectedMember)}
+    >
+      Promote to Member
+    </button>
+  );
+
+  const memeberArchiveUnArchiveButton = archived ? (
+    <button
+      className={classNames.moveToMember}
+      type="button"
+      onClick={() => archiveTheMember(selectedMember)}
+    >
+      Unarchive Member
+    </button>
+  ) : (
+    <button
+      className={classNames.moveToMember}
+      type="button"
+      onClick={() => archiveTheMember(selectedMember)}
+    >
+      Archive Member
+    </button>
+  );
+
   const renderPromoteButton = () => {
     return (
       <>
-        {member ? (
-          <button
-            className={classNames.moveToMember}
-            type="button"
-            onClick={() => promoteToMember(selectedMember)}
-          >
-            Demote Member
-          </button>
-        ) : (
-          <button
-            className={classNames.moveToMember}
-            type="button"
-            onClick={() => promoteToMember(selectedMember)}
-          >
-            Promote to Member
-          </button>
-        )}
-        {archived ? (
-          <button
-            className={classNames.moveToMember}
-            type="button"
-            onClick={() => archiveTheMember(selectedMember)}
-          >
-            Unarchive Member
-          </button>
-        ) : (
-          <button
-            className={classNames.moveToMember}
-            type="button"
-            onClick={() => archiveTheMember(selectedMember)}
-          >
-            Archive Member
-          </button>
-        )}
+        {memberRoleUpdateButton}
+        {memeberArchiveUnArchiveButton}
 
         <br />
 

--- a/src/components/member-role-update/index.js
+++ b/src/components/member-role-update/index.js
@@ -73,39 +73,23 @@ const MemberRoleUpdate = () => {
     }
   };
 
-  const memberRoleUpdateButton = member ? (
+  const memberRoleUpdateButton = (
     <button
       className={classNames.moveToMember}
       type="button"
       onClick={() => promoteDemoteAMember(userId)}
     >
-      Demote Member
-    </button>
-  ) : (
-    <button
-      className={classNames.moveToMember}
-      type="button"
-      onClick={() => promoteDemoteAMember(userId)}
-    >
-      Promote to Member
+      {member ? 'Demote Member' : 'Promote to Member'}
     </button>
   );
 
-  const memeberArchiveUnArchiveButton = archived ? (
+  const memeberArchiveUnArchiveButton = (
     <button
       className={classNames.moveToMember}
       type="button"
       onClick={() => archiveUnArchiveTheMember(userId)}
     >
-      Unarchive Member
-    </button>
-  ) : (
-    <button
-      className={classNames.moveToMember}
-      type="button"
-      onClick={() => archiveUnArchiveTheMember(userId)}
-    >
-      Archive Member
+      {archived ? 'Unarchive Member' : 'Archive Member'}
     </button>
   );
 

--- a/src/components/member-role-update/index.js
+++ b/src/components/member-role-update/index.js
@@ -23,64 +23,52 @@ const MemberRoleUpdate = () => {
     `${BASE_API_URL}/users/${selectedMember}`
   );
 
-  const member = userData?.user.roles.member;
-  const archived = userData?.user.roles.archived;
+  const member = userData?.user?.roles.member;
+  const archived = userData?.user?.roles.archived;
   const userId = userData?.user.id;
   const { data: tagData } = useFetch(`${BASE_API_URL}/tags`);
   const { data: levelData } = useFetch(`${BASE_API_URL}/levels`);
 
-  const promoteToMember = async (id) => {
+  const promoteDemoteAMember = async (id) => {
+    let memberRole = null;
     setIsUpdating(true);
-    const role = {
-      member: true,
-    };
-    const { status } = await memberRoleUpdate(id, role);
-    setIsUpdating(false);
-    if (status === 200) {
-      setUpdateStatus('user promoted to a member');
+    if (member) {
+      memberRole = false;
     } else {
+      memberRole = true;
+    }
+    const role = {
+      member: memberRole,
+    };
+    try {
+      const { status } = await memberRoleUpdate(id, role);
+      setIsUpdating(false);
+      if (status === 200) {
+        setUpdateStatus('user promoted to a member');
+      }
+    } catch (error) {
       setUpdateStatus('some error occured, please contact admin');
     }
   };
 
-  const demoteFromMember = async (id) => {
+  const archiveUnArchiveTheMember = async (id) => {
+    let archiveRole = null;
     setIsUpdating(true);
-    const role = {
-      member: false,
-    };
-    const { status } = await memberRoleUpdate(id, role);
-    setIsUpdating(false);
-    if (status === 200) {
-      setUpdateStatus('user deomoted from member');
+    if (archived) {
+      archiveRole = false;
     } else {
-      setUpdateStatus('some error occured, please contact admin');
+      archiveRole = true;
     }
-  };
-
-  const archiveTheMember = async (id) => {
-    setIsUpdating(true);
     const role = {
-      archived: true,
+      archived: archiveRole,
     };
-    const { status } = await memberRoleUpdate(id, role);
-    setIsUpdating(false);
-    if (status === 200) {
-      setUpdateStatus('user archived!');
-    } else {
-      setUpdateStatus('Some error occured, please contact admin');
-    }
-  };
-
-  const unArchiveMember = async (id) => {
-    setIsUpdating(true);
-    const role = {
-      archived: false,
-    };
-    const { status } = await memberRoleUpdate(id, role);
-    setIsUpdating(false);
-    if (status === 200) {
-      setUpdateStatus('user un-archived!');
-    } else {
+    try {
+      const { status } = await memberRoleUpdate(id, role);
+      setIsUpdating(false);
+      if (status === 200) {
+        setUpdateStatus('user archived!');
+      }
+    } catch (error) {
       setUpdateStatus('Some error occured, please contact admin');
     }
   };
@@ -89,7 +77,7 @@ const MemberRoleUpdate = () => {
     <button
       className={classNames.moveToMember}
       type="button"
-      onClick={() => demoteFromMember(userId)}
+      onClick={() => promoteDemoteAMember(userId)}
     >
       Demote Member
     </button>
@@ -97,7 +85,7 @@ const MemberRoleUpdate = () => {
     <button
       className={classNames.moveToMember}
       type="button"
-      onClick={() => promoteToMember(userId)}
+      onClick={() => promoteDemoteAMember(userId)}
     >
       Promote to Member
     </button>
@@ -107,7 +95,7 @@ const MemberRoleUpdate = () => {
     <button
       className={classNames.moveToMember}
       type="button"
-      onClick={() => unArchiveMember(userId)}
+      onClick={() => archiveUnArchiveTheMember(userId)}
     >
       Unarchive Member
     </button>
@@ -115,7 +103,7 @@ const MemberRoleUpdate = () => {
     <button
       className={classNames.moveToMember}
       type="button"
-      onClick={() => archiveTheMember(userId)}
+      onClick={() => archiveUnArchiveTheMember(userId)}
     >
       Archive Member
     </button>

--- a/src/helper-functions/action-handlers.js
+++ b/src/helper-functions/action-handlers.js
@@ -1,24 +1,18 @@
 import { fetch } from './fetch';
 import {
-  getAddMemberRoleURL,
   getUserProfileSelf,
-  getArchiveMemberURL,
   getTaskUpdateURL,
   getTagAssignURL,
+  updateMemberRole,
 } from './urls';
 
-const moveToMember = (user) =>
-  fetch(getAddMemberRoleURL(user), 'patch', null, null, null, {
+const memberRoleUpdate = (user, role) =>
+  fetch(updateMemberRole(user), 'patch', null, role, null, {
     withCredentials: true,
   });
 
 const getUserSelf = () =>
   fetch(getUserProfileSelf, 'get', null, null, null, {
-    withCredentials: true,
-  });
-
-const archiveMember = (user) =>
-  fetch(getArchiveMemberURL(user), 'patch', null, null, null, {
     withCredentials: true,
   });
 
@@ -46,4 +40,4 @@ const assignTags = (data) =>
     }
   );
 
-export { archiveMember, moveToMember, getUserSelf, moveTask, assignTags };
+export { getUserSelf, moveTask, assignTags, memberRoleUpdate };

--- a/src/helper-functions/urls.js
+++ b/src/helper-functions/urls.js
@@ -59,8 +59,6 @@ export {
   getCloudinaryImgURL,
   getActiveTasksURL,
   getUserProfileSelf,
-  // getAddMemberRoleURL,
-  // getArchiveMemberURL,
   getTaskUpdateURL,
   getTagAssignURL,
   updateMemberRole,

--- a/src/helper-functions/urls.js
+++ b/src/helper-functions/urls.js
@@ -40,11 +40,8 @@ const getActiveTasksURL = (rdsId) => `${baseURL}/tasks/${rdsId}?status=active`;
  *
  * @param {string} rdsId
  */
-const getAddMemberRoleURL = (rdsId) =>
-  `${baseURL}/members/moveToMembers/${rdsId}`;
 
-const getArchiveMemberURL = (rdsId) =>
-  `${baseURL}/members/archiveMembers/${rdsId}`;
+const updateMemberRole = (rdsId) => `${baseURL}/users/${rdsId}/temporary/data`;
 
 /**
  *
@@ -62,8 +59,9 @@ export {
   getCloudinaryImgURL,
   getActiveTasksURL,
   getUserProfileSelf,
-  getAddMemberRoleURL,
-  getArchiveMemberURL,
+  // getAddMemberRoleURL,
+  // getArchiveMemberURL,
   getTaskUpdateURL,
   getTagAssignURL,
+  updateMemberRole,
 };


### PR DESCRIPTION
### What is the change?

The superuser should be able to promote/demote a member or archive/unarchive a member when the superuser presses the alt key, the settings button appears when clicking on the settings button super user gets a modal where he can perform above mentioned task and the same modal should work on members page as well.

### Close #533 
### Close #539 

### Is it a bug?
No

### \*Dev Tested?

- [x] Yes
- [ ] No


> For visual or interaction changes. Can be a video/screenshot.

https://github.com/Real-Dev-Squad/website-members/assets/82165483/98480e94-f5b1-4302-b0bb-f62097b51fef

API is under development so unarchiving and demoting functionality is not built so in UI it's not working but  after the API is built, have created follow-up issue and will handle that in that issue - 

https://github.com/Real-Dev-Squad/website-api-contracts/tree/main/users#patch-usersidtemporarydata 

### Follow-up issue 
#548
