### PR TITLE
FIX: Address issue with missing 'archivedMember' property

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -45,7 +45,7 @@ export async function getServerSideProps(context) {
     const { members } = await res.json();
 
     for (const memberData of members) {
-      const { picture, isMember, first_name, archivedMember } = memberData;
+      const { picture, isMember, first_name, roles } = memberData;
 
       const img_url = picture
         ? getCloudinaryImgURL(
@@ -63,7 +63,7 @@ export async function getServerSideProps(context) {
       }
 
       // Filtering New Members
-      if (!isMember && !archivedMember && first_name) {
+      if (!isMember && first_name && roles.in_discord) {
         newMembersDetails.push({
           ...memberData,
           img_url,


### PR DESCRIPTION
### What is the change?

Currently, new users are filtered based on the `archivedMember` property, which is not coming from the backend so it is undefined. Removed the `archivedMember` check and updated the condition of the filter based on the`in_discord` property.

This will complete the first task of this issue https://github.com/Real-Dev-Squad/website-members/issues/541

### \*Dev Tested?

- [x] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [x] Web

#### Browsers

- [x] Chrome
- [ ] Safari
- [x] Firefox

### Before / After Change Screenshots

Before:

![Screenshot (72)](https://github.com/Real-Dev-Squad/website-members/assets/79859472/c424fc65-25d8-4339-b288-e7d34f3a7152)
![Screenshot (73)](https://github.com/Real-Dev-Squad/website-members/assets/79859472/8c88db5c-b01f-47e1-8e52-c62c157f8f6f)

After:

![Screenshot (74)](https://github.com/Real-Dev-Squad/website-members/assets/79859472/c3b1cc52-d056-45b0-8149-c208a23f79ab)
