### PR TITLE
fixed completion date error msg for falsy start date

### DIFF
--- a/src/components/member-profile/active-task/index.js
+++ b/src/components/member-profile/active-task/index.js
@@ -5,14 +5,20 @@ import { percentageofDaysRemaining } from '@helper-functions/taskProgress';
 import { estimatedDays } from '@helper-functions/estimated-days';
 import { progressIndicator } from '@helper-functions/progressIndicator';
 
-const ActiveTask = ({ taskDetails }) => {
+const ActiveTask = ({ taskDetails, devUser }) => {
   const { title, purpose, startedOn, endsOn, percentCompleted } = taskDetails;
-  const completedDate = timeWas(startedOn * 1000, false, endsOn * 1000);
+  const completedDate = timeWas(
+    startedOn * 1000,
+    false,
+    endsOn * 1000,
+    devUser
+  );
   const percentOfTaskLeft = 100 - percentCompleted;
   const percentageOfDaysRemaining = percentageofDaysRemaining(
     startedOn,
     endsOn,
-    completedDate
+    completedDate,
+    devUser
   );
   const showEstimatedDay = estimatedDays(
     percentageOfDaysRemaining,

--- a/src/components/member-profile/contribution-type/index.js
+++ b/src/components/member-profile/contribution-type/index.js
@@ -52,7 +52,7 @@ const renderActiveTasks = (tasks, devUser) => {
   if (devUser) {
     if (tasks?.length > 0) {
       return tasks.map((task, index) => {
-        return <ActiveTask key={index} taskDetails={task} />;
+        return <ActiveTask key={index} taskDetails={task} devUser={devUser} />;
       });
     }
     return (

--- a/src/components/member-profile/contribution/index.js
+++ b/src/components/member-profile/contribution/index.js
@@ -115,22 +115,22 @@ const ContributionCard = ({
   if (isTitleAvailable) {
     if (status !== 'VERIFIED') {
       completedText = <span>Estimated Completion: </span>;
-      completedDate = timeWas(startedOn * 1000, false, endsOn * 1000);
+      completedDate = timeWas(startedOn * 1000, false, endsOn * 1000, devUser);
     } else {
-      completedDate = timeWas(startedOn * 1000, false, endsOn * 1000);
+      completedDate = timeWas(startedOn * 1000, false, endsOn * 1000, devUser);
       completedText = <span>Completed in: </span>;
-      featureLiveDate = timeWas(endsOn * 1000, true);
+      featureLiveDate = timeWas(endsOn * 1000, true, Date.now(), devUser);
       featureLiveOnText = featureLiveDate;
     }
   } else {
     const createdAt = +new Date(prList[0].createdAt);
     const updatedAt = +new Date(prList[0].updatedAt);
     if (prList[0].state === 'closed') {
-      completedDate = timeWas(createdAt, false, updatedAt);
+      completedDate = timeWas(createdAt, false, updatedAt, devUser);
       completedText = (
         <span className={classNames.completedText}>Completed in </span>
       );
-      featureLiveDate = timeWas(updatedAt, true);
+      featureLiveDate = timeWas(updatedAt, true, Date.now(), devUser);
       featureLiveOnText = featureLiveDate;
     }
   }
@@ -202,7 +202,7 @@ ContributionCard.propTypes = {
   imageLink: PropTypes.string.isRequired,
   devUser: PropTypes.bool.isRequired,
   url: PropTypes.string.isRequired,
-  urlObj: PropTypes.instanceOf(Object).isRequired,
+  urlObj: PropTypes.instanceOf(URL).isRequired,
 };
 
 export default Contribution;

--- a/src/constants/error-messages.js
+++ b/src/constants/error-messages.js
@@ -4,3 +4,4 @@ export const emptyContributionsError =
   'No Contributions have been received yet.';
 export const emptyNoteworthyContributionsError =
   'It would be wonderful to see some noteworthy contributions made.';
+export const notAvailableError = 'N/A';

--- a/src/helper-functions/taskProgress.js
+++ b/src/helper-functions/taskProgress.js
@@ -1,8 +1,13 @@
 import { timeWas } from '@helper-functions/time-was';
 
-const percentageofDaysRemaining = (startedOn, endsOn, completedDate) => {
-  const startDate = timeWas(startedOn * 1000, true, endsOn * 1000);
-  const endDate = timeWas(endsOn * 1000, true, startDate * 1000);
+const percentageofDaysRemaining = (
+  startedOn,
+  endsOn,
+  completedDate,
+  devUser
+) => {
+  const startDate = timeWas(startedOn * 1000, true, endsOn * 1000, devUser);
+  const endDate = timeWas(endsOn * 1000, true, startDate * 1000, devUser);
   const date1 = new Date(startDate);
   const date2 = new Date(endDate);
   const diffTime = Math.abs(date2 - date1);

--- a/src/helper-functions/time-was.js
+++ b/src/helper-functions/time-was.js
@@ -1,6 +1,16 @@
+import { notAvailableError } from '@constants/error-messages';
+
 const calc = (interval, cycle) => Math.floor(cycle / interval);
 
-function timeWas(timestamp, completeDate = false, differentNow = Date.now()) {
+function timeWas(
+  timestamp,
+  completeDate = false,
+  differentNow = Date.now(),
+  devUser
+) {
+  if (devUser && (!timestamp || timestamp === 0)) {
+    return notAvailableError;
+  }
   const timeInSec = Math.floor(differentNow - timestamp) / 1000;
 
   /**

--- a/src/test/unit/components/member-profile/index.test.js
+++ b/src/test/unit/components/member-profile/index.test.js
@@ -8,6 +8,7 @@ import {
   emptyActiveTasksError,
   emptyContributionsError,
   emptyNoteworthyContributionsError,
+  notAvailableError,
 } from '@constants/error-messages';
 
 const notaMember = {
@@ -127,6 +128,92 @@ describe('Members Profile', () => {
       emptyNoteworthyContributionsError
     );
     expect(emptyNoteworthyContributionsErrorElement).toBeInTheDocument();
+  });
+  it('Should render notAvailable error message in completion date, if start date is falsy inside task/contrbution object', () => {
+    const tasksWithEmptyStartDateAsFalsy = [
+      {
+        id: 'eHjZi3jzyqep43GvK2Rf',
+        percentCompleted: 50,
+        endsOn: '1698085740',
+        github: {
+          issue: {
+            html_url: 'https://github.com/Real-Dev-Squad/mobile-app/issues/263',
+            id: '1914069956',
+            assignee: 'harshitadatra',
+            status: 'open',
+          },
+        },
+        createdBy: 'amitprakash',
+        assignee: 'prakash',
+        title: 'Animation enhancement in Goals page',
+        type: 'feature',
+        priority: 'TBD',
+        startedOn: null,
+        status: 'IN_PROGRESS',
+        featureUrl:
+          'https://github.com/Real-Dev-Squad/website-members/issues/562',
+        assigneeId: 'YzEVZ50DHr37oL1mqqbO',
+      },
+    ];
+
+    const contributionsWithStartDateAsFalsy = {
+      all: [
+        {
+          task: {
+            id: 'CdsWvmW2c9h5D08bHsYa',
+            title: 'Dummy Title',
+            endsOn: '1697155200',
+            startedOn: '0',
+            status: 'COMPLETED',
+            featureUrl:
+              'https://github.com/Real-Dev-Squad/website-members/issues/562',
+            participants: [],
+          },
+          prList: [],
+        },
+      ],
+      noteworthy: [
+        {
+          task: {
+            id: 'CdsWvmW2c9h5D08bHsYa',
+            title: 'Dummy Title',
+            endsOn: '1697155200',
+            startedOn: undefined,
+            featureUrl:
+              'https://github.com/Real-Dev-Squad/website-members/issues/562',
+            status: 'COMPLETED',
+            participants: [],
+          },
+          prList: [],
+        },
+      ],
+    };
+    render(
+      <KeyboardProvider
+        initialValue={{
+          isOptionKeyPressed: true,
+          setIsOptionKeyPressed: jest.fn(),
+        }}
+      >
+        <UserContextProvider value={initialUserContext}>
+          <TaskContextProvider>
+            <Profile
+              membersData={isaMember}
+              devUser
+              tasks={tasksWithEmptyStartDateAsFalsy}
+              contributions={contributionsWithStartDateAsFalsy}
+            />
+          </TaskContextProvider>
+        </UserContextProvider>
+      </KeyboardProvider>
+    );
+    const notAvailableCompletetionDateElements =
+      screen.queryAllByText(notAvailableError);
+    notAvailableCompletetionDateElements.forEach((element) => {
+      expect(element).toHaveTextContent(notAvailableError);
+    });
+
+    expect(notAvailableCompletetionDateElements).toHaveLength(3);
   });
 
   it('Should render the info icon correctly', () => {


### PR DESCRIPTION
Fixes https://github.com/Real-Dev-Squad/website-members/issues/562 

### What is the change?
Design Doc: https://docs.google.com/document/d/1JvBDR9Kfo0pzfl-fM7tLZO7WmmRAWbCVFNDgHqnos1k/edit?usp=sharing

If "startedOn" key is falsy i.e undefined/null/0 then completion date should show as 'N/A', so updated timeWas fn to handle this case.

### Is it bug?
Yes

- Steps to repro
Go to https://members.realdevsquad.com/amitprakash any member profile and you will see some contribution/task where completion date is NAN sec or 54 years which is invalid.

- Expected
![image](https://github.com/Real-Dev-Squad/website-members/assets/22474104/ac525789-545b-422f-9945-ceb1f59b650f)

- Actual
![image](https://github.com/Real-Dev-Squad/website-members/assets/22474104/e4ebdecb-06e2-4582-808c-e25508a26ccc)

### \*Dev Tested?

- [x] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [x] Web

#### Browsers

- [x] Chrome
- [ ] Safari
- [ ] Firefox

### Before / After Change Screenshots
- Before
![image](https://github.com/Real-Dev-Squad/website-members/assets/22474104/449fa87e-ecff-4860-b242-62bb14da650a)

- After
![image](https://github.com/Real-Dev-Squad/website-members/assets/22474104/1b72ef53-aba8-4604-9b34-b7310cbde5a3)

Test results:

![image](https://github.com/Real-Dev-Squad/website-members/assets/22474104/37934b95-c9a9-40fd-b21a-f115e76e02f9)

